### PR TITLE
Migrate to use rally-openstack package

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,10 @@
-=============================
-xRally with OpenStack plugins
-=============================
+=====================================
+xRally plugins for OpenStack platform
+=====================================
 
-The official mirror of tagged releases of xRally with OpenStack plugins
+The official mirror of tagged releases of xRally plugins for `OpenStack
+platform <https://openstack.org>`_
+
 
 The goal of the repository
 --------------------------
@@ -16,9 +18,9 @@ At the moment it's used to automate Docker image builds for https://hub.docker.c
 Contribute
 -----------
 
-The main development are goint at:
+The main development are going at:
 
-* https://git.openstack.org/cgit/openstack/rally - All development is done through Gerrit
-* https://github.com/openstack/rally - GitHub Mirror of Gerrit repo provided by OpenStack infra team (read only access)
+* https://git.openstack.org/cgit/openstack/rally-openstack - All development is done through Gerrit
+* https://github.com/openstack/rally-openstack - GitHub Mirror of Gerrit repo provided by OpenStack infra team (read only access)
 
 See https://rally.readthedocs.io/en/0.10.1/contribute.html for contributing details.


### PR DESCRIPTION
In-tree OpenStack plugins are deprecated in https://github.com/openstack/rally
All these plugins moved to the separate repo and we should use it for a
Docker image.